### PR TITLE
Load 32 bit Windows modules

### DIFF
--- a/src/win_maps.rs
+++ b/src/win_maps.rs
@@ -10,7 +10,8 @@ use winapi::shared::minwindef::{FALSE, DWORD, BOOL};
 use winapi::um::dbghelp::{PSYMBOL_INFOW, SYMBOL_INFOW, SymInitializeW, SymCleanup, PMODLOAD_DATA};
 use winapi::um::handleapi::{INVALID_HANDLE_VALUE, CloseHandle};
 use winapi::um::processthreadsapi::OpenProcess;
-use winapi::um::tlhelp32::{CreateToolhelp32Snapshot, TH32CS_SNAPMODULE, MODULEENTRY32W, Module32FirstW, Module32NextW};
+use winapi::um::tlhelp32::{CreateToolhelp32Snapshot, TH32CS_SNAPMODULE, TH32CS_SNAPMODULE32};
+use winapi::um::tlhelp32::{MODULEENTRY32W, Module32FirstW, Module32NextW};
 use winapi::um::winnt::{HANDLE, PROCESS_VM_READ, PCWSTR};
 
 pub type Pid = u32;
@@ -57,7 +58,7 @@ impl MapRange  {
 
 pub fn get_process_maps(pid: Pid) -> io::Result<Vec<MapRange>> {
     unsafe {
-        let handle = CreateToolhelp32Snapshot(TH32CS_SNAPMODULE, pid);
+        let handle = CreateToolhelp32Snapshot(TH32CS_SNAPMODULE | TH32CS_SNAPMODULE32, pid);
         if handle == INVALID_HANDLE_VALUE {
             return Err(io::Error::last_os_error());
         }


### PR DESCRIPTION
When getting the module snapshot, we were only getting the 64bit libraries
loaded up for a process. This caused issues when trying to resolve
symbols up a 32-bit ruby process (https://github.com/rbspy/rbspy/issues/172)

Fix by passing TH32CS_SNAPMODULE32 in addition to TH32CS_SNAPMODULE to also
get a list of the 32 bit windows libraries.