### PR TITLE
only include `failure` on macos

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,11 +9,11 @@ repository = "https://github.com/benfred/proc-maps"
 
 [dependencies]
 libc = "0.2.54"
-failure = "0.1.1"
 
 [target.'cfg(target_os="macos")'.dependencies]
 mach = "0.1.2"
 libproc = "0.3.1"
+failure = "0.1.1"
 
 [target.'cfg(windows)'.dependencies]
 winapi = {version = "0.3", features = ["tlhelp32", "processthreadsapi", "handleapi", "impl-default", "dbghelp"]}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,8 +23,9 @@
 //! ```
 
 extern crate libc;
-extern crate failure;
 
+#[cfg(target_os = "macos")]
+extern crate failure;
 #[cfg(target_os = "macos")]
 extern crate mach;
 #[cfg(target_os = "macos")]


### PR DESCRIPTION
The depreciated `failure` crate is only used on in the macos.  This PR makes `failure` a `target_os` dependency.