### PR TITLE
FreeBSD: Fix iterator use-after-free bug

### DIFF
--- a/src/freebsd_maps/mod.rs
+++ b/src/freebsd_maps/mod.rs
@@ -10,8 +10,6 @@ use std::convert::From;
 
 pub type Pid = pid_t;
 
-const FILE_NAME_BUFFER_LENGTH: usize = 4096;
-
 #[derive(Debug, Clone)]
 pub struct MapRange {
     range_start: usize,
@@ -38,90 +36,21 @@ impl MapRange {
     }
 }
 
-impl From<ptrace::vm_entry> for MapRange {
-    fn from(vm_entry: ptrace::vm_entry) -> Self {
-        let pathname = string_from_cstr_ptr(vm_entry.pve_path);
-
+impl From<ptrace::VmEntry> for MapRange {
+    fn from(vm_entry: ptrace::VmEntry) -> Self {
         Self {
             range_start: vm_entry.pve_start as usize,
             range_end: vm_entry.pve_end as usize,
             protection: vm_entry.pve_prot as _,
             offset: vm_entry.pve_offset as usize,
             vnode: vm_entry.pve_fileid as usize,
-            pathname: pathname,
-        }
-    }
-}
-
-#[derive(Default)]
-struct VmEntryIterator {
-    current: c_int,
-    pid: Pid,
-}
-
-impl VmEntryIterator {
-    fn new(pid: Pid) -> std::io::Result<Self> {
-        ptrace::attach(pid)?;
-
-        Ok(Self { current: 0, pid })
-    }
-}
-
-impl Drop for VmEntryIterator {
-    fn drop(&mut self) {
-        ptrace::detach(self.pid);
-    }
-}
-
-impl Iterator for VmEntryIterator {
-    type Item = ptrace::vm_entry;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        let Self { current, pid } = *self;
-        // If the region was mapped from a file, `pve_path` contains filename.
-        let pve_pathlen = 4096;
-        let pve_path: [c_char; FILE_NAME_BUFFER_LENGTH] =
-            [0; FILE_NAME_BUFFER_LENGTH];
-
-        let entry = Self::Item {
-            pve_entry: current,
-            pve_path: &pve_path as *const _ as *mut _,
-            pve_pathlen: pve_pathlen,
-            ..Default::default()
-        };
-
-        let result = ptrace::read_vm_entry(pid, entry);
-
-        match result {
-            Ok(entry) => {
-                self.current = entry.pve_entry;
-                Some(entry)
-            }
-            _ => None
-        }
-    }
-}
-
-fn string_from_cstr_ptr(pointer: *const c_char) -> Option<String> {
-    if pointer.is_null() {
-        None
-    } else {
-        unsafe {
-            let result = CStr::from_ptr(pointer)
-                .to_string_lossy()
-                .into_owned();
-
-            if result.len() > 0 {
-                Some(result)
-            } else {
-                None
-            }
+            pathname: vm_entry.pve_path,
         }
     }
 }
 
 pub fn get_process_maps(pid: Pid) -> std::io::Result<Vec<MapRange>> {
-    let iter = VmEntryIterator::new(pid)?;
+    let iter = ptrace::VmEntryIterator::new(pid)?;
 
     Ok(iter.map(MapRange::from).collect())
 }

--- a/src/freebsd_maps/mod.rs
+++ b/src/freebsd_maps/mod.rs
@@ -88,6 +88,8 @@ fn test_write_xor_execute_policy() -> () {
 
     child.kill();
 
+    assert!(maps.len() > 0, "No process maps were found");
+
     let write_and_exec_regions = maps
         .iter()
         .any(|x| x.is_write() && x.is_exec());

--- a/src/freebsd_maps/ptrace.rs
+++ b/src/freebsd_maps/ptrace.rs
@@ -24,6 +24,54 @@ impl Default for vm_entry {
     }
 }
 
+#[derive(Debug, Clone)]
+pub struct VmEntry {
+    pub pve_entry: i32,
+    pub pve_timestamp: i32,
+    pub pve_start: u64,
+    pub pve_end: u64,
+    pub pve_offset: u64,
+    pub pve_prot: u32,
+    pub pve_pathlen: u32,
+    pub pve_fileid: i64,
+    pub pve_fsid: u32,
+    pub pve_path: Option<String>,
+}
+
+impl From<vm_entry> for VmEntry {
+    fn from(vm_entry: vm_entry) -> Self {
+        Self {
+            pve_entry: vm_entry.pve_entry,
+            pve_timestamp: vm_entry.pve_timestamp,
+            pve_start: vm_entry.pve_start,
+            pve_end: vm_entry.pve_end,
+            pve_offset: vm_entry.pve_offset,
+            pve_prot: vm_entry.pve_prot,
+            pve_pathlen: vm_entry.pve_pathlen,
+            pve_fileid: vm_entry.pve_fileid,
+            pve_fsid: vm_entry.pve_fsid,
+            pve_path: string_from_cstr_ptr(vm_entry.pve_path),
+        }
+    }
+}
+
+impl Default for VmEntry {
+    fn default() -> Self {
+        Self {
+            pve_entry: 0,
+            pve_timestamp: 0,
+            pve_start: 0,
+            pve_end: 0,
+            pve_offset: 0,
+            pve_prot: 0,
+            pve_pathlen: 0,
+            pve_fileid: 0,
+            pve_fsid: 0,
+            pve_path: None,
+        }
+    }
+}
+
 extern "C" {
     fn ptrace(request: c_int,
               pid: Pid,


### PR DESCRIPTION
This is a small step towards fixing FreeBSD support in rbspy. There's currently a use-after-free bug in `VmEntryIterator` that causes `get_process_maps` to return invalid file paths in some cases. I've restructured the iterator so that it returns a struct with safe types, specifically a `String` instead of a raw pointer to memory that's quickly freed. It would be nice to use something like `PathBuf` when we can -- saving that for later.

This also unblocks migrating CI to GitHub Actions, which I'll do in a followup PR.

There's at least one more issue blocking rbspy from working properly on FreeBSD that I'll look into when I have more time.