### PR TITLE
Return Path instead of String for safety and portability

### DIFF
--- a/src/freebsd_maps/mod.rs
+++ b/src/freebsd_maps/mod.rs
@@ -6,6 +6,7 @@ mod ptrace;
 use libc::{c_int, pid_t};
 use std::convert::From;
 use std::iter::Iterator;
+use std::path::{Path, PathBuf};
 
 pub type Pid = pid_t;
 
@@ -16,7 +17,7 @@ pub struct MapRange {
     protection: c_int,
     offset: usize,
     vnode: usize,
-    pathname: Option<String>,
+    pathname: Option<PathBuf>,
 }
 
 impl MapRange {
@@ -26,8 +27,8 @@ impl MapRange {
     pub fn start(&self) -> usize {
         self.range_start
     }
-    pub fn filename(&self) -> &Option<String> {
-        &self.pathname
+    pub fn filename(&self) -> Option<&Path> {
+        self.pathname.as_deref()
     }
 
     pub fn is_read(&self) -> bool {
@@ -73,7 +74,7 @@ fn test_map_from_invoked_binary_present() -> () {
 
     let maybe_cat_region = maps
         .iter()
-        .find(|x| x.filename() == &Some(String::from("/bin/cat")));
+        .find(|map| map.filename() == Some(&PathBuf::from("/bin/cat")));
 
     assert!(
         maybe_cat_region.is_some(),

--- a/src/linux_maps.rs
+++ b/src/linux_maps.rs
@@ -2,6 +2,7 @@ use libc;
 use std;
 use std::fs::File;
 use std::io::Read;
+use std::path::{Path, PathBuf};
 
 pub type Pid = libc::pid_t;
 
@@ -17,7 +18,7 @@ pub struct MapRange {
     pub dev: String,
     pub flags: String,
     pub inode: usize,
-    pathname: Option<String>,
+    pathname: Option<PathBuf>,
 }
 
 impl MapRange {
@@ -30,8 +31,8 @@ impl MapRange {
         self.range_start
     }
     /// Returns the filename of the loaded module
-    pub fn filename(&self) -> &Option<String> {
-        &self.pathname
+    pub fn filename(&self) -> Option<&Path> {
+        self.pathname.as_deref()
     }
     /// Returns whether this range contains executable code
     pub fn is_exec(&self) -> bool {
@@ -74,6 +75,11 @@ fn parse_proc_maps(contents: &str) -> Vec<MapRange> {
         let offset = split.next().unwrap();
         let dev = split.next().unwrap();
         let inode = split.next().unwrap();
+        let pathname = match Some(split.collect::<Vec<&str>>().join(" ")).filter(|x| !x.is_empty())
+        {
+            Some(s) => Some(PathBuf::from(s)),
+            None => None,
+        };
 
         vec.push(MapRange {
             range_start: usize::from_str_radix(range_start, 16).unwrap(),
@@ -82,7 +88,7 @@ fn parse_proc_maps(contents: &str) -> Vec<MapRange> {
             dev: dev.to_string(),
             flags: flags.to_string(),
             inode: usize::from_str_radix(inode, 10).unwrap(),
-            pathname: Some(split.collect::<Vec<&str>>().join(" ")).filter(|x| !x.is_empty()),
+            pathname,
         });
     }
     vec
@@ -100,7 +106,7 @@ fn test_parse_maps() {
             dev: "00:14".to_string(),
             flags: "r-xp".to_string(),
             inode: 205736,
-            pathname: Some("/usr/bin/fish".to_string()),
+            pathname: Some(PathBuf::from("/usr/bin/fish")),
         },
         MapRange {
             range_start: 0x00708000,
@@ -118,7 +124,7 @@ fn test_parse_maps() {
             dev: "00:00".to_string(),
             flags: "rw-p".to_string(),
             inode: 0,
-            pathname: Some("[heap]".to_string()),
+            pathname: Some(PathBuf::from("[heap]")),
         },
         MapRange {
             range_start: 0x7f438053b000,
@@ -127,9 +133,9 @@ fn test_parse_maps() {
             dev: "fd:01".to_string(),
             flags: "r--p".to_string(),
             inode: 59034409,
-            pathname: Some(
-                "/usr/lib/x86_64-linux-gnu/libgmodule-2.0.so.0.4200.6 (deleted)".to_string(),
-            ),
+            pathname: Some(PathBuf::from(
+                "/usr/lib/x86_64-linux-gnu/libgmodule-2.0.so.0.4200.6 (deleted)",
+            )),
         },
     ];
     assert_eq!(vec, expected);


### PR DESCRIPTION
Fixes #4

This is partly based on #2. While it represents a breaking change to the API, the downstream effects should be straightforward to handle. My WIP changes to rbspy are here: https://github.com/acj/rbspy/commit/333b96ab21b18b0e5f30ada496e7ef6f6a358369.

@benfred, if you have time, I'd be grateful for more eyes on this.