### PR TITLE
Use VirtualQueryEx to completely enumerate VM mappings on Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ mach2 = "0.4.0"
 libproc = "0.10.0"
 
 [target.'cfg(windows)'.dependencies]
-winapi = {version = "0.3", features = ["tlhelp32", "processthreadsapi", "handleapi", "impl-default", "dbghelp"]}
+winapi = {version = "0.3", features = ["tlhelp32", "processthreadsapi", "handleapi", "impl-default", "dbghelp", "memoryapi", "sysinfoapi"]}
 
 [target.'cfg(target_os="freebsd")'.build-dependencies]
 bindgen = { version = "0.59.1", optional = true }


### PR DESCRIPTION
I noticed that the Windows implementation of this crate wasn't finding a memory region that I knew existed in the target process, and was able to confirm the presence of with [Cheat Engine](https://www.cheatengine.org/). With this patch, `proc-maps` now returns anonymous memory regions not associated with any executable/DLL image, in addition to those that are.

This change also addresses #6 (missing memory protection info).

This came up while working on [Pinput](https://github.com/VyrCossont/Pinput), which uses `proc-maps` to find the memory used by the target fantasy console.